### PR TITLE
Update Dockerfile to Install MDBook

### DIFF
--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -27,6 +27,6 @@ ENV PATH=/home/jenkins/.cargo/bin:$PATH
 
 RUN rustup component add rustfmt
 
-# RUN cargo install mdbook --vers ${MDBOOK_RELEASE}
+RUN cargo install mdbook --vers ${MDBOOK_RELEASE}
 
 


### PR DESCRIPTION
Because we are going to generate docs with Jenkins instead of Netlify we need mdbook installed.