### PR TITLE
Add `rust-src` component so WASM target may build.

### DIFF
--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -75,4 +75,5 @@ RUN cargo install mdbook --vers ${MDBOOK_RELEASE}
 
 # WASM, including `nodejs` above
 RUN rustup target add wasm32-unknown-unknown
+RUN rustup component add rust-src
 RUN curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -76,4 +76,5 @@ RUN cargo install mdbook --vers ${MDBOOK_RELEASE}
 # WASM, including `nodejs` above
 RUN rustup target add wasm32-unknown-unknown
 RUN rustup component add rust-src
+RUN cargo install wasm-bindgen-cli
 RUN curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh


### PR DESCRIPTION
Necessary for WASM target to compile, based on [this build failure](https://jenkins.amethyst-engine.org/blue/organizations/jenkins/amethyst/detail/feature%2F2192%2Ffix-gl-rendering/6/pipeline).